### PR TITLE
Ability to read from node.js Buffer

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -23,6 +23,7 @@ function IconEntry() {
   this.isCompressed = false
   this.description = null
   this.osVersion = null
+  this.ignore = false
 
 }
 
@@ -47,7 +48,18 @@ IconEntry.prototype = {
 
     var type = Icns.TYPE[ this.type ]
 
-    if( type == null ) {
+    let newTypes = [ "info" ];//, "ic04", "ic05" ]
+
+    let found = newTypes.find((element) => {
+      return element == this.type
+    })
+
+    if (found) {
+      this.ignore = true;
+      return this;
+    }
+
+    if( type == null) {
       throw new Error( `Unknown icns resource type "${this.type}"` )
     }
 

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -48,7 +48,7 @@ IconEntry.prototype = {
 
     var type = Icns.TYPE[ this.type ]
 
-    let newTypes = [ "info" ];//, "ic04", "ic05" ]
+    let newTypes = [ "info", "TOC " ];//, "ic04", "ic05" ]
 
     let found = newTypes.find((element) => {
       return element == this.type

--- a/lib/icns.js
+++ b/lib/icns.js
@@ -11,12 +11,18 @@ function Icns( filename, options ) {
     return new Icns( filename, options )
   }
 
-  this.filename = filename
+  if (filename instanceof Buffer) {
+    this.filename = 'generic'
+    this._buffer = filename
+  } else {
+    this.filename = filename
+    this._buffer = null;
+  }
+
   this.fd = null
   this.options = Object.assign({}, Icns.defaults, options)
   this.header = new Icns.Header()
   this.entries = []
-
 }
 
 /**
@@ -27,17 +33,93 @@ Icns.prototype = {
 
   constructor: Icns,
 
+  openBuffer( callback ) {
+
+  },
+
+  readHeaderFromBuffer( callback ) {
+    var buffer = Buffer.alloc( 8 )
+    var offset = 0
+    var length = buffer.length
+    var position = 0
+
+    this._buffer.copy(buffer, offset, 0, 8);
+
+    this.header.parse( buffer )
+    callback && callback()
+  },
+
+  readEntriesFromBuffer( callback ) {
+    var buffer = Buffer.alloc( 16 )
+    var length = buffer.length
+    var position = 8
+    var offset = position + length
+
+    this.entries.length = 0
+
+    var read = ( next ) => {
+
+      this._buffer.copy(buffer, 0, position, position + 16)
+
+      var entry = new Icns.IconEntry().parse( buffer )
+
+      if (!entry.ignore) {
+        entry.offset = position
+
+        if( buffer.indexOf( Icns.JPEG2000, 8 ) === 8 ) {
+          entry.format = 'jpeg2000'
+        } else if( buffer.indexOf( Icns.PNG, 8 ) === 8 ) {
+          entry.format = 'png'
+        }
+      }
+
+      position += entry.length
+
+      next( null, entry )
+    }
+
+    var run = ( error, entry ) => {
+
+      if( error ) {
+        return callback( error )
+      }
+
+      if( entry ) {
+        this.entries.push( entry )
+      }
+
+      if( position < this.header.length ) {
+        read( run )
+      } else {
+        callback( null, this.entries )
+      }
+
+    }
+
+    run()
+
+  },
+
   open( callback ) {
-    fs.open( this.filename, this.options.flags, this.options.mode, ( error, fd ) => {
-      if( error ) return callback( error )
-      this.fd = fd
-      this.readHeader(( error ) => {
-        if( error ) return callback( error )
-        this.readEntries(( error ) => {
+    if ( this._buffer != null ) {
+      this.readHeaderFromBuffer(( error ) => {
+        if ( error ) return callback( error )
+        this.readEntriesFromBuffer(( error ) => {
           callback( error )
         })
       })
-    })
+    } else {
+      fs.open( this.filename, this.options.flags, this.options.mode, ( error, fd ) => {
+        if( error ) return callback( error )
+        this.fd = fd
+        this.readHeader(( error ) => {
+          if( error ) return callback( error )
+          this.readEntries(( error ) => {
+            callback( error )
+          })
+        })
+      })
+    }
   },
 
   readHeader( callback ) {
@@ -78,12 +160,14 @@ Icns.prototype = {
 
         var entry = new Icns.IconEntry().parse( buffer )
 
-        entry.offset = position
+        if (!entry.ignore) {
+          entry.offset = position
 
-        if( buffer.indexOf( Icns.JPEG2000, 8 ) === 8 ) {
-          entry.format = 'jpeg2000'
-        } else if( buffer.indexOf( Icns.PNG, 8 ) === 8 ) {
-          entry.format = 'png'
+          if( buffer.indexOf( Icns.JPEG2000, 8 ) === 8 ) {
+            entry.format = 'jpeg2000'
+          } else if( buffer.indexOf( Icns.PNG, 8 ) === 8 ) {
+            entry.format = 'png'
+          }
         }
 
         position += entry.length
@@ -112,7 +196,6 @@ Icns.prototype = {
     }
 
     run()
-
   },
 
   readEntryData( entry, callback ) {
@@ -124,19 +207,25 @@ Icns.prototype = {
     var position = entry.offset + 8
     var offset = 0
 
-    fs.read( this.fd, buffer, offset, length, position, ( error, bytesRead, buffer ) => {
-      if( !error && ( bytesRead !== length ) ) {
-        error = new Error( `Bytes read mismatch; expected ${length}, read ${bytesRead}` )
-      }
-      // TODO: Run-length encoding
-      // if( entry.format === 'raw' ) {
-      //   console.log( 'input', buffer )
-      //   var channels = Icns.rle.decode( entry, buffer )
-      //   console.log( 'channels', channels )
-      //   buffer = Icns.rle.continuous( entry, channels )
-      // }
-      callback( error, buffer )
-    })
+    if ( this._buffer != null ) {
+      this._buffer.copy( buffer, offset , position, position + length)
+      callback( '', buffer )
+    } else {
+      fs.read( this.fd, buffer, offset, length, position, ( error, bytesRead, buffer ) => {
+        if( !error && ( bytesRead !== length ) ) {
+          error = new Error( `Bytes read mismatch; expected ${length}, read ${bytesRead}` )
+        }
+
+        // TODO: Run-length encoding
+        // if( entry.format === 'raw' ) {
+        //   console.log( 'input', buffer )
+        //   var channels = Icns.rle.decode( entry, buffer )
+        //   console.log( 'channels', channels )
+        //   buffer = Icns.rle.continuous( entry, channels )
+        // }
+        callback( error, buffer )
+      })
+    }
 
   },
 
@@ -187,9 +276,12 @@ Icns.TYPE = {
   'h8mk': { length: 2304, width: 48, height: 48, channels: 1, depth: 8, format: 'raw', isMask: true, os: '8.5', description: '48×48 8-bit mask' },
   'it32': { length: -1, width: 128, height: 128, channels: 3, depth: 24, format: 'raw', os: '10.0', description: '128×128 24-bit icon' },
   't8mk': { length: 16384, width: 128, height: 128, channels: 1, depth: 8, format: 'raw', isMask: true, os: '10.0', description: '128×128 8-bit mask' },
+  'ic04': { length: -1, width: 16, height: 16, channels: -1, depth: -1, format: null, os: '10.7', description: '16×16 icon in JPEG 2000 or PNG format' },
   'icp4': { length: -1, width: 16, height: 16, channels: -1, depth: -1, format: null, os: '10.7', description: '16×16 icon in JPEG 2000 or PNG format' },
   'icp5': { length: -1, width: 32, height: 32, channels: -1, depth: -1, format: null, os: '10.7', description: '32×32 icon in JPEG 2000 or PNG format' },
+  'ic05': { length: -1, width: 32, height: 32, channels: -1, depth: -1, format: null, os: '10.7', description: '32×32 icon in JPEG 2000 or PNG format' },
   'icp6': { length: -1, width: 64, height: 64, channels: -1, depth: -1, format: null, os: '10.7', description: '64×64 icon in JPEG 2000 or PNG format' },
+  'ic06': { length: -1, width: 64, height: 64, channels: -1, depth: -1, format: null, os: '10.7', description: '64×64 icon in JPEG 2000 or PNG format' },
   'ic07': { length: -1, width: 128, height: 128, channels: -1, depth: -1, format: null, os: '10.7', description: '128×128 icon in JPEG 2000 or PNG format' },
   'ic08': { length: -1, width: 256, height: 256, channels: -1, depth: -1, format: null, os: '10.5', description: '256×256 icon in JPEG 2000 or PNG format' },
   'ic09': { length: -1, width: 512, height: 512, channels: -1, depth: -1, format: null, os: '10.5', description: '512×512 icon in JPEG 2000 or PNG format' },

--- a/lib/icns.js
+++ b/lib/icns.js
@@ -33,10 +33,6 @@ Icns.prototype = {
 
   constructor: Icns,
 
-  openBuffer( callback ) {
-
-  },
-
   readHeaderFromBuffer( callback ) {
     var buffer = Buffer.alloc( 8 )
     var offset = 0


### PR DESCRIPTION
Hi,

I came across your neat library to help me get MacOS folder icons in Hyper terminal. I made it work and it's at https://github.com/moimart/hyper-folder-icon. I'd like to be able to merge my changes with your mainline.

The main change is to able to read from a Buffer, not only from a file path. While testing the changes, I found there are some entries new in MacOS that your parser still does not acknowledge. I added the ability to ignore certain entries and saw that there are new ic05 and ic06 entries which I duplicated from other existing ones. I haven't tested those entries, though.

Let me know if it needs more polishing.

Thanks!

Br,
Moises